### PR TITLE
[DEV] 기초 레이아웃 구성 - 좌측 메뉴 제거

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -919,13 +919,14 @@ button .button .link {
     min-height: 18px !important;
 }
 #main_view {
-    /* position: relative; */
+    position: relative;
     /* outline: none; */
     /* border: none; */
     margin-top: 10px;
     /* margin-bottom: 150px; */
     /* margin-right: 0px; */
     height: 100%;
+    left: -150px;
     /* margin-left: 0px; */
     /* overflow-x: hidden; */
     /* overflow-y: scroll; */
@@ -933,7 +934,7 @@ button .button .link {
     /* padding-top: 25px; */
     /* padding-bottom: 40px; */
     /* z-index: 0; */
-    /* width: 100%; */
+    width: 100%;
     /* background: red; */
     /* box-sizing: border-box; */
 

--- a/src/index.html
+++ b/src/index.html
@@ -335,7 +335,7 @@
 
         </div>
 
-        <div id="minibar" class="">
+        <div id="minibar" class="" style="display: none">
 
             <div class="items">
 
@@ -367,7 +367,7 @@
 
         </div>
 
-        <aside id="sidebar" draggable="true" class="sidebar sidebar-left" tabindex="1">
+        <aside id="sidebar" draggable="true" class="sidebar sidebar-left" tabindex="1" style="display: none">
 
             <div id="sidebar_items" class="items">
             </div>


### PR DESCRIPTION
## Summary
파일 탐색기의 좌측에 있는 불필요한 메뉴를 제거했습니다.

## Description
파일 탐색기 좌측에 있는 아직 미완성된 부분을 제거하는 작업을 진행했습니다.  
작업은 다음과 같습니다.
* 파일 탐색기 옆에 있는 사이드 바(sidebar) 지우기
* 파일 탐색기 맨 왼쪽에 있는 미니 바(minbar) 지우기  

### UI 스크린샷
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/52999093/236217021-322267b2-d66a-45d5-9d06-258ea87b0db5.png">
