### PR TITLE
[FIX] VCS 관련 Refresh 적용

### DIFF
--- a/main.js
+++ b/main.js
@@ -3529,14 +3529,14 @@ ipcMain.on("show-context-menu-files", (e, args) => {
             gitMenuList.push({
                 label: "Git: Untrack",
                 click: () => {
-                    runGitCommand(args.href, "git rm --cached");
+                    runGitCommand(args.href, "git rm --cached", e);
                 },
             });
             // git rm
             gitMenuList.push({
                 label: "Git: Delete",
                 click: () => {
-                    runGitCommand(args.href, "git rm");
+                    runGitCommand(args.href, "git rm", e);
                 },
             });
             // git mv
@@ -3551,7 +3551,7 @@ ipcMain.on("show-context-menu-files", (e, args) => {
             gitMenuList.push({
                 label: "Git: Add to Stage",
                 click: () => {
-                    runGitCommand(args.href, "git add");
+                    runGitCommand(args.href, "git add", e);
                 },
             });
         } else if (fileStatus === 2) {
@@ -3559,14 +3559,14 @@ ipcMain.on("show-context-menu-files", (e, args) => {
             gitMenuList.push({
                 label: "Git: Add to Stage",
                 click: () => {
-                    runGitCommand(args.href, "git add");
+                    runGitCommand(args.href, "git add", e);
                 },
             });
             // git restore
             gitMenuList.push({
                 label: "Git: Undo Modification",
                 click: () => {
-                    runGitCommand(args.href, "git restore");
+                    runGitCommand(args.href, "git restore", e);
                 },
             });
         } else if (fileStatus === 3) {
@@ -3574,7 +3574,7 @@ ipcMain.on("show-context-menu-files", (e, args) => {
             gitMenuList.push({
                 label: "Git: Unstage",
                 click: () => {
-                    runGitCommand(args.href, "git restore --staged");
+                    runGitCommand(args.href, "git restore --staged", e);
                 },
             });
         }
@@ -3687,7 +3687,7 @@ const getGitStatus = (filePath, isDirectory) => {
     });
 };
 
-const runGitCommand = (filePath, gitCmd) => {
+const runGitCommand = (filePath, gitCmd, e) => {
     let filePathDir = path.dirname(filePath).replaceAll(' ', '\\ ');
     filePath = filePath.replaceAll(" ", "\\ ");
     let cmd = `cd ${filePathDir} && ${gitCmd} ${filePath}`;
@@ -3700,6 +3700,7 @@ const runGitCommand = (filePath, gitCmd) => {
             console.log(`Stderr: ${stderr}`);
             resolve(-1);
         }
+        e.sender.send("refresh");
         resolve(1);
     });
 };

--- a/main.js
+++ b/main.js
@@ -3873,6 +3873,7 @@ ipcMain.on("git_commit_confirmed", (e, filePath, commit_message_input_str) => {
             console.log(`Stderr: ${stderr}`);
             resolve(-1);
         }
+        BrowserWindow.getFocusedWindow().send("refresh");
     });
 });
 

--- a/main.js
+++ b/main.js
@@ -3747,6 +3747,7 @@ ipcMain.on("git_rename_confirmed", (e, filePath, rename_input_str) => {
     confirm.hide();
 
     let filePathDir = path.dirname(filePath).replaceAll(" ", "\\ ");
+    filePath = filePath.replaceAll(" ", "\\ ");
     let cmd = `cd ${filePathDir} && git mv ${filePath} ${rename_input_str}`;
     exec(cmd, (error, stdout, stderr) => {
         if (error) {

--- a/main.js
+++ b/main.js
@@ -3764,7 +3764,7 @@ ipcMain.on("git_rename_canceled", (e) => {
     confirm.hide();
 });
 
-function gitInitialize(dirPath) {
+function gitInitialize(dirPath, e) {
     let cmd = `cd ${dirPath} && git init`;
     exec(cmd, (error, stdout, stderr) => {
         if (error) {
@@ -3776,6 +3776,7 @@ function gitInitialize(dirPath) {
             return;
         }
         console.log(stdout);
+        e.sender.send("refresh");
     });
 }
 
@@ -3793,7 +3794,7 @@ ipcMain.on("git_init", (e) => {
         }
 
         if (stdout.trim() === "0") {
-            gitInitialize(dirPath);
+            gitInitialize(dirPath, e);
         }
     });
 });

--- a/main.js
+++ b/main.js
@@ -3758,6 +3758,7 @@ ipcMain.on("git_rename_confirmed", (e, filePath, rename_input_str) => {
             console.log(`Stderr: ${stderr}`);
             resolve(-1);
         }
+        BrowserWindow.getFocusedWindow().send("refresh");
     });
 });
 

--- a/src/git_rename_dialog.html
+++ b/src/git_rename_dialog.html
@@ -21,7 +21,7 @@
 
         <div>
             <input id="btn_git_rename_cancel" tabindex="2" class="ui small button default" type="button" value="Cancel">
-            <input id="btn_git_rename_confirm" tabindex="1" autofocus class="ui small button default red" type="button" value="Delete">
+            <input id="btn_git_rename_confirm" tabindex="1" autofocus class="ui small button default red" type="button" value="Rename">
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- VCS 기능에 Refresh 기능을 적용하였습니다.

## Description
- `git init` 명령 수행 시, UI를 Refresh하는 로직을 추가하였습니다.
- `git commit` 명령 수행 시, UI를 Refresh하는 로직을 추가하였습니다.
- `Git Stage` 관련 명령(`Add to Stage` / `Unstage` / `Delete` / `Rename` / `Untrack` 수행 시, UI를 Refresh하는 로직을 추가하였습니다.
- `Git Rename` 명령 수행 시, 경로에 공백이 포함된 경우 오류가 발생하던 현상을 개선하였습니다. 
- `Git Rename` 명령 수행 시 표시되는 다이얼로그의 버튼 텍스트를 수정하였습니다.
- `git commit`과 `Git Rename` 명령 수행 시 UI Refresh를 호출하는 과정에서, 입력 Dialog 표시로 인해 Browser Window가 달라져, `FocusedWindow` 객체가 달라지는 문제로 인해 까다로운 부분이 있었습니다. 이 두 가지 경우에 대해서는, `e.sender.send("refresh");`가 아닌, `BrowserWindow.getFocusedWindow().send("refresh");`와 같이 Browser Window를 직접 가져와 IPC 시그널을 보내는 방식으로 작업하였습니다.