### PR TITLE
[FIX] VCS Unstage 예외처리

### DIFF
--- a/main.js
+++ b/main.js
@@ -3574,7 +3574,7 @@ ipcMain.on("show-context-menu-files", (e, args) => {
             gitMenuList.push({
                 label: "Git: Unstage",
                 click: () => {
-                    runGitCommand(args.href, "git restore --staged", e);
+                    runGitCommand(args.href, "git rm --cached", e);
                 },
             });
         }


### PR DESCRIPTION
## Summary
- VCS 기능 중, `Unstage` 기능의 문제를 해결하였습니다.

## Description
- `git restore --staged` 명령 수행 시, 기존에 Commit이 0개인 경우, 올바르게 동작하지 않는 문제가 있습니다.
- `Staged` 상태의 특정 파일을 `Unstaged` 상태로 변환시킨다는 목적을 유지하되, Commit 수에 영향받지 않도록 `git rm --cached` 명령으로 동일한 기능을 하도록 수정하였습니다.